### PR TITLE
Added allegor/marathon-consul in community tools

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -133,6 +133,9 @@ description: |-
         <a href="https://github.com/spring-cloud/spring-cloud-consul">Spring Cloud Consul</a> - Service discovery, configuration and events for Spring Cloud
       </li>
       <li>
+        <a href="https://github.com/allegro/marathon-consul">marathon-consul</a> - Service registry bridge for Marathon 
+      </li>
+      <li>
         <a href="https://github.com/CiscoCloud/marathon-consul">marathon-consul</a> - Bridge from Marathon apps to the Consul K/V store
       </li>
       <li>


### PR DESCRIPTION
With @dankraw we authored https://github.com/allegro/marathon-consul/ this is fork of https://github.com/CiscoCloud/marathon-consul that is no longer developed (see this comment https://github.com/CiscoCloud/marathon-consul/issues/17#issuecomment-161678453).